### PR TITLE
Button title

### DIFF
--- a/Flair/Flair/Extensions/UIButton+Style.swift
+++ b/Flair/Flair/Extensions/UIButton+Style.swift
@@ -40,6 +40,17 @@ import Foundation
             }
         }
 
+        /// Sets a title to be displayed for all control states. Similar to calling `setTitle(for:)` for each control state, but it will use the formatting from `Style`.
+        /// This behaves exactly like `setTitle(for:)` if the `style` property is `nil`
+        ///
+        /// - Parameter newTitle: The text to display
+        public func setStyled(title newTitle: String?) {
+            setStyled(title: newTitle, for: .normal)
+            setStyled(title: newTitle, for: .highlighted)
+            setStyled(title: newTitle, for: .selected)
+            setStyled(title: newTitle, for: .disabled)
+        }
+
         /// Sets a title to be displayed for the state. Similar to `setTitle(for:)` but it will preserve the formatting you expect for the `Style`.
 
         /// This behaves exactly like `setTitle(for:)` if the `style` property is `nil`


### PR DESCRIPTION
Normally you set a button's title via `setStyled(title:for:)` but you have to call this for each `UIControlState`. That gives you a lot of control, but since a `Style.textColor's ColorSet` has up to 4 different colors (1 for each control state) it's often redundant. So I added a method that sets a single title for all the control states.